### PR TITLE
Added github action workflow to format files with Black

### DIFF
--- a/.github/workflows/black_formatter.yml
+++ b/.github/workflows/black_formatter.yml
@@ -1,0 +1,31 @@
+name: Black Formatting
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  format:
+    name: Format with Black
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install black
+
+      - name: Run Black
+        run: black .


### PR DESCRIPTION
1. Added GitHub actions workflow to format the files (whenever pushed to the repo directly or through a PR) with Black (https://black.readthedocs.io/en/stable/).
2. This will help the developer to not care about the formatting style across the codebase, and it will be uniform. 
3. Workflow will be triggered on - **a)** Pull Request to `main` branch & **b)** Direct Pushes to the `main` branch