### PR TITLE
Updated black_formatter.yml

### DIFF
--- a/.github/workflows/black_formatter.yml
+++ b/.github/workflows/black_formatter.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
   format:
@@ -29,3 +26,13 @@ jobs:
 
       - name: Run Black
         run: black .
+      
+      - name: Configure Git
+        run: |
+          git config --global user.name "${GIT_AUTHOR_NAME}"
+          git config --global user.email "${GIT_AUTHOR_EMAIL}"
+
+      - name: Amend Previous Commit With Same Commit Message
+        run: |
+          git commit --amend --no-edit
+          git push --force-with-lease


### PR DESCRIPTION
1. The problem was this - this formatter was running on a pull request and also, before merging to the `main` branch.
2. BUT after it ran and formatted the files, those files were reverted to their original state - because we were not committing them. In short, this `black-formatter` was just existent and not influencing the main repo at all before the code merge.
3. Now, I have added a snippet to this .yml file just for this purpose. 
4. I have also removed the 'formatting on a pull request' section because that is repetitive - since the code will be formatted for final, before merging into the `main` branch, which is exactly what we want - properly formatted code in the main repo. 