### PR TITLE
Added github workflow for generating documentation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,24 @@
+name: ci 
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - uses: actions/cache@v2
+        with:
+          key: ${{ github.ref }}
+          path: .cache
+      - run: pip install mkdocs-material
+      - run: pip install mkdocstrings
+      - run: pip install mkdocstrings-python
+      - run: pip install pillow cairosvg
+      - run: mkdocs gh-deploy --force


### PR DESCRIPTION
1. This workflow will run on every push to the `main` branch of this project. 
2. This will publish the documentation at https://swanseauniversitymedical.github.io/pyconceptlibraryclient/ (Right now it is not the latest version for obvious reasons). 
3. Once, #19 & #20 are merged along with this PR, one can visit the afore-mentioned URL to see the changes. 