### PR TITLE
update:  Primary Publication

### DIFF
--- a/pyconceptlibraryclient/phenotypes.py
+++ b/pyconceptlibraryclient/phenotypes.py
@@ -230,9 +230,6 @@ class Phenotypes(Endpoint):
         result['data']['concept_information']
       )
 
-    if 'publications' in result['data'].keys():
-      result['data']['publications'] = utils.try_parse_doi(result['data']['publications'])
-
     result['data'] = {k: v for k, v in result['data'].items() if k not in PHENOTYPE_IGNORED_WRITE_FIELDS}
 
     return result
@@ -321,7 +318,6 @@ class Phenotypes(Endpoint):
     '''
     
     '''
-    print(data)
     result = {}
     for key, value in data[0].items():
       if not value:
@@ -352,8 +348,8 @@ class Phenotypes(Endpoint):
         continue
 
       if isinstance(value, list):
-        fields = {k: [v[k] for v in value] for k in value[0]}
-        field_keys = fields.keys()
+        field_keys = set([k for v in value for k in v])
+        fields = { k: [v.get(k) for v in value] for k in field_keys }
 
         if 'value' in field_keys:
           new_value = fields['value']
@@ -363,9 +359,7 @@ class Phenotypes(Endpoint):
           result[key] = new_value
           continue
 
-        if 'doi' in field_keys:
-          result[key] = fields['details']
-          continue
+        result[key] = value
 
       if isinstance(value, dict):
         field_keys = value.keys()

--- a/pyconceptlibraryclient/utils.py
+++ b/pyconceptlibraryclient/utils.py
@@ -39,20 +39,28 @@ def try_parse_doi(publications: list) -> list:
     publications (list): List of publications from entity definition file
 
   Returns:
-    List of dicts, 'detail' key contains original publication details and 'doi' containing
-    parsed DOI or None  
+      List of dicts:
+        - 'details': Original publication details.
+        - 'doi': Parsed DOI or None.
+        - 'primary': True if marked as [primary] in text ignores case and whitespace, otherwise False.
   '''
   pattern = re.compile(r'\b(10[.][0-9]{4,}(?:[.][0-9]+)*\/(?:(?![\"&\'<>])\S)+)\b')
+  primary_pattern = re.compile(r'\[\s*primary\s*\]', re.IGNORECASE)
 
   output = [ ]
   for publication in publications:
     if publication is None or len(str(publication).strip()) < 1:
       continue
 
+    is_primary = bool(primary_pattern.search(publication))  # Check if marker exists
+    publication_cleaned = primary_pattern.sub("", publication).strip()  # Remove marker from text
     doi = pattern.findall(publication)
+
     output.append({
-      'details': publication,
-      'doi': doi[0] if len(doi) > 0 else None
+      'details': publication_cleaned,
+      'doi': doi[0] if len(doi) > 0 else None,
+      'primary': is_primary
     })
   
   return output
+

--- a/pyconceptlibraryclient/utils.py
+++ b/pyconceptlibraryclient/utils.py
@@ -39,27 +39,20 @@ def try_parse_doi(publications: list) -> list:
     publications (list): List of publications from entity definition file
 
   Returns:
-      List of dicts:
-        - 'details': Original publication details.
-        - 'doi': Parsed DOI or None.
-        - 'primary': True if marked as [primary] in text ignores case and whitespace, otherwise False.
+    List of dicts, 'detail' key contains original publication details and 'doi' containing
+    parsed DOI or None  
   '''
   pattern = re.compile(r'\b(10[.][0-9]{4,}(?:[.][0-9]+)*\/(?:(?![\"&\'<>])\S)+)\b')
-  primary_pattern = re.compile(r'\[\s*primary\s*\]', re.IGNORECASE)
 
   output = [ ]
   for publication in publications:
     if publication is None or len(str(publication).strip()) < 1:
       continue
 
-    is_primary = bool(primary_pattern.search(publication))  # Check if marker exists
-    publication_cleaned = primary_pattern.sub("", publication).strip()  # Remove marker from text
     doi = pattern.findall(publication)
-
     output.append({
-      'details': publication_cleaned,
-      'doi': doi[0] if len(doi) > 0 else None,
-      'primary': is_primary
+      'details': publication,
+      'doi': doi[0] if len(doi) > 0 else None
     })
   
   return output


### PR DESCRIPTION
[Updated] utils.try_parse_doi to support primary publication detection for BHF templates
	•	Added support for detecting [PRIMARY] (handling case/whitespace variations) markers in publication text.
	•	The function removes [PRIMARY] (handling case/whitespace variations) before processing.
	•	Introduced a primary flag in the output to indicate if a publication is marked as primary.